### PR TITLE
Adhere to naming convention for embedded grammars

### DIFF
--- a/grammars/knitr.cson
+++ b/grammars/knitr.cson
@@ -98,7 +98,8 @@
     'endCaptures':
       '1':
         'name': 'punctuation.definition.arguments.end.latex'
-    'name': 'source.embedded.r'
+    'contentName': 'source.embedded.r'
+    'name': 'meta.block.source.r'
     'patterns': [
       {
         'include': 'source.r'

--- a/grammars/knitr.cson
+++ b/grammars/knitr.cson
@@ -51,7 +51,7 @@
         'name': 'punctuation.section.embedded.begin.knitr'
       '2':
         'name': 'comment.line.other.knitr'
-    'contentName': 'source.r.embedded.knitr'
+    'contentName': 'source.embedded.r'
     'end': '^(@)(.*)$'
     'endCaptures':
       '1':
@@ -80,7 +80,7 @@
         'name': 'punctuation.definition.arguments.begin.latex'
       '2':
         'name': 'punctuation.definition.arguments.end.latex'
-    'contentName': 'source.r.embedded.knitr'
+    'contentName': 'source.embedded.r'
     'end': '^\\\\end(\\{)Scode(\\})'
     'name': 'meta.block.source.r'
     'patterns': [
@@ -98,7 +98,7 @@
     'endCaptures':
       '1':
         'name': 'punctuation.definition.arguments.end.latex'
-    'name': 'source.r.embedded.knitr'
+    'name': 'source.embedded.r'
     'patterns': [
       {
         'include': 'source.r'


### PR DESCRIPTION
Other language packages, like [markdown](https://github.com/atom/language-gfm/blob/master/grammars/gfm.cson#L873), [reStructuredText](https://github.com/Lukasa/language-restructuredtext/blob/master/grammars/restructuredtext.cson#L695) or [asciidoc](https://github.com/asciidoctor/atom-language-asciidoc/blob/master/grammars/language-asciidoc.cson#L4101) use the convention `source.embedded.r` for embedded languages.

In [Hydrogen](https://github.com/nteract/hydrogen/) we use this name to allow users to execute a code block interactively (see https://github.com/nteract/hydrogen/pull/637).

Here is a example of how this looks in `asciidoc`:
![asciidoc](https://cloud.githubusercontent.com/assets/13285808/24292879/77cfa724-108f-11e7-9ffd-14d7358010ec.gif)

It would be great if `language-knitr` would adhere to this standard so we can support knitr as well.

/cc @bmpvieira