### PR TITLE
Added support for indented regions

### DIFF
--- a/grammars/knitr.cson
+++ b/grammars/knitr.cson
@@ -4,12 +4,12 @@
   'snw'
   'rnw'
 ]
-'foldingStartMarker': '^<<(.?*)>>=|\\\\begin\\{.*\\}'
-'foldingStopMarker': '^@(.?*)$|\\\\end\\{.*\\}'
+'foldingStartMarker': '^\\s*<<(.?*)>>=|\\\\begin\\{.*\\}'
+'foldingStopMarker': '^\\s*@(.?*)$|\\\\end\\{.*\\}'
 'name': 'Knitr'
 'patterns': [
   {
-    'begin': '^(<<)'
+    'begin': '^\\s*(<<)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.parameters.begin.knitr'
@@ -52,7 +52,7 @@
       '2':
         'name': 'comment.line.other.knitr'
     'contentName': 'source.embedded.r'
-    'end': '^(@)(.*)$'
+    'end': '^\\s*(@)(.*)$'
     'endCaptures':
       '1':
         'name': 'punctuation.section.embedded.end.knitr'


### PR DESCRIPTION
Knitr considers indented regions valid.  Added support for indented
regions by modifying begin and end regular expressions to permit
zero or more whitespace characters before the tokens.

Also modified folding markers in case atom/first-mate#48 is ever
fixed.